### PR TITLE
Miro

### DIFF
--- a/src/Keboola/Syrup/Command/CreateJobCommand.php
+++ b/src/Keboola/Syrup/Command/CreateJobCommand.php
@@ -75,9 +75,9 @@ class CreateJobCommand extends ContainerAwareCommand
         $job = $this->jobManager->createJob($command, $params);
 
         // Add job to Elasticsearch
-        $jobId = $this->jobManager->indexJob($job);
+        $job = $this->jobManager->indexJob($job);
 
-        $output->writeln('Created job id ' . $jobId);
+        $output->writeln('Created job id ' . $job->getId());
 
         // Run Job
         if (!$input->getOption('no-run')) {
@@ -86,7 +86,7 @@ class CreateJobCommand extends ContainerAwareCommand
             $returnCode = $runJobCommand->run(
                 new ArrayInput([
                     'command'   => 'syrup:run-job',
-                    'jobId'     => $jobId
+                    'jobId'     => $job->getId()
                 ]),
                 $output
             );

--- a/src/Keboola/Syrup/Command/JobCommand.php
+++ b/src/Keboola/Syrup/Command/JobCommand.php
@@ -142,7 +142,7 @@ class JobCommand extends ContainerAwareCommand
             'pid'   => getmypid()
         ]);
 
-        $this->jobManager->updateJob($this->job);
+        $this->job = $this->jobManager->updateJob($this->job);
 
         // Instantiate jobExecutor based on component name
         $jobExecutorName = str_replace('-', '_', $this->job->getComponent()) . '.job_executor';
@@ -201,7 +201,7 @@ class JobCommand extends ContainerAwareCommand
             ];
             $this->job->setStatus($jobStatus);
             $this->job->setResult($jobResult);
-            $this->jobManager->updateJob($this->job);
+            $this->job = $this->jobManager->updateJob($this->job);
 
             // try to log the exception
             $exceptionId = $this->logException('critical', $e);
@@ -220,7 +220,7 @@ class JobCommand extends ContainerAwareCommand
         $this->job->setResult($jobResult);
         $this->job->setEndTime(date('c', $endTime));
         $this->job->setDurationSeconds($duration);
-        $this->jobManager->updateJob($this->job);
+        $this->job = $this->jobManager->updateJob($this->job);
 
         // postExecution action
         try {

--- a/src/Keboola/Syrup/Controller/ApiController.php
+++ b/src/Keboola/Syrup/Controller/ApiController.php
@@ -52,7 +52,7 @@ class ApiController extends BaseController
 
         // Add job to Elasticsearch
         try {
-            $jobId = $this->getJobManager()->indexJob($job);
+            $job = $this->getJobManager()->indexJob($job);
         } catch (\Exception $e) {
             throw new ApplicationException("Failed to create job", $e);
         }
@@ -64,7 +64,7 @@ class ApiController extends BaseController
         if (isset($queueParams['sqs'])) {
             $queueName = $queueParams['sqs'];
         }
-        $messageId = $this->enqueue($jobId, $queueName);
+        $messageId = $this->enqueue($job->getId(), $queueName);
 
         $this->logger->info('Job created', [
             'sqsQueue' => $queueName,
@@ -74,8 +74,8 @@ class ApiController extends BaseController
 
         // Response with link to job resource
         return $this->createJsonResponse([
-            'id'        => $jobId,
-            'url'       => $this->getJobUrl($jobId),
+            'id'        => $job->getId(),
+            'url'       => $this->getJobUrl($job->getId()),
             'status'    => $job->getStatus()
         ], 202);
     }

--- a/src/Keboola/Syrup/Job/Metadata/Job.php
+++ b/src/Keboola/Syrup/Job/Metadata/Job.php
@@ -23,36 +23,38 @@ class Job implements JobInterface
 
     protected $type;
 
+    protected $version;
+
     protected $data = [
-        'id'        => null,
-        'runId'     => null,
-        'lockName'  => null,
-        'project'   => [
-            'id'        => null,
-            'name'      => null
+        'id' => null,
+        'runId' => null,
+        'lockName' => null,
+        'project' => [
+            'id' => null,
+            'name' => null
         ],
-        'token'     => [
-            'id'            => null,
-            'description'   => null,
-            'token'         => null
+        'token' => [
+            'id' => null,
+            'description' => null,
+            'token' => null
         ],
         'component' => null,
-        'command'   => null,
-        'params'    => [],
-        'result'    => [],
-        'status'    => null,
-        'process'   => [
-            'host'      => null,
-            'pid'       => null
+        'command' => null,
+        'params' => [],
+        'result' => [],
+        'status' => null,
+        'process' => [
+            'host' => null,
+            'pid' => null
         ],
-        'createdTime'   => null,
-        'startTime'     => null,
-        'endTime'       => null,
-        'durationSeconds'   => null,
-        'waitSeconds'       => null
+        'createdTime' => null,
+        'startTime' => null,
+        'endTime' => null,
+        'durationSeconds' => null,
+        'waitSeconds' => null
     ];
 
-    public function __construct(array $data = [], $index = null, $type = null)
+    public function __construct(array $data = [], $index = null, $type = null, $version = null)
     {
         $this->data['status'] = self::STATUS_WAITING;
         $this->data = array_merge($this->data, $data);
@@ -66,6 +68,7 @@ class Job implements JobInterface
 
         $this->index = $index;
         $this->type = $type;
+        $this->version = $version;
     }
 
     public function getIndex()
@@ -76,6 +79,11 @@ class Job implements JobInterface
     public function getType()
     {
         return $this->type;
+    }
+
+    public function getVersion()
+    {
+        return $this->version;
     }
 
     public function getId()

--- a/src/Keboola/Syrup/Job/Metadata/JobInterface.php
+++ b/src/Keboola/Syrup/Job/Metadata/JobInterface.php
@@ -81,5 +81,7 @@ interface JobInterface
 
     public function getType();
 
+    public function getVersion();
+
     public function getLogData();
 }

--- a/src/Keboola/Syrup/Job/Metadata/JobManager.php
+++ b/src/Keboola/Syrup/Job/Metadata/JobManager.php
@@ -205,7 +205,7 @@ class JobManager
      * @param $jobId
      * @return Job|null
      */
-    public function getJob($jobId)
+    public function getJob($jobId, $component = null)
     {
         foreach ($this->getIndices() as $index) {
             try {
@@ -327,9 +327,12 @@ class JobManager
         return $results;
     }
 
-    public function getIndex()
+    public function getIndex($component = null)
     {
-        return $this->config['index_prefix'] . '_syrup_' . $this->componentName;
+        if ($component == null) {
+            $component = $this->componentName;
+        }
+        return $this->config['index_prefix'] . '_syrup_' . $component;
     }
 
     public function getIndexCurrent()
@@ -352,11 +355,11 @@ class JobManager
         return null;
     }
 
-    protected function getIndices()
+    protected function getIndices($component = null)
     {
         try {
             return array_keys($this->client->indices()->getAlias([
-                'name'  => $this->getIndex()
+                'name'  => $this->getIndex($component)
             ]));
         } catch (Missing404Exception $e) {
             return null;

--- a/src/Keboola/Syrup/Service/Queue/QueueFactory.php
+++ b/src/Keboola/Syrup/Service/Queue/QueueFactory.php
@@ -37,4 +37,21 @@ class QueueFactory
 
         return new QueueService($queueConfig, $this->componentName);
     }
+
+    public function create($sqsName)
+    {
+        $client = SqsClient::factory([
+            'region' => 'us-east-1'
+        ]);
+
+        $result = $client->createQueue([
+            'QueueName'  => $sqsName,
+            'Attributes' => [
+                'DelaySeconds'       => 5,
+                'MaximumMessageSize' => 4096
+            ]
+        ]);
+
+        return $result->getAll();
+    }
 }

--- a/tests/Keboola/Syrup/Command/JobCommandTest.php
+++ b/tests/Keboola/Syrup/Command/JobCommandTest.php
@@ -41,38 +41,38 @@ class JobCommandTest extends WebTestCase
             ->encrypt(self::$kernel->getContainer()->getParameter('storage_api.test.token'));
 
         // job execution test
-        $jobId = $jobManager->indexJob($this->createJob($encryptedToken));
+        $job = $jobManager->indexJob($this->createJob($encryptedToken));
 
         $command = $this->application->find('syrup:run-job');
         $commandTester = new CommandTester($command);
         $commandTester->execute(
             array(
-                'jobId'   => $jobId
+                'jobId' => $job->getId()
             )
         );
 
         $this->assertEquals(0, $commandTester->getStatusCode());
 
-        $job = $jobManager->getJob($jobId);
+        $job = $jobManager->getJob($job->getId());
         $this->assertNotNull($job);
         $this->assertEquals($job->getStatus(), Job::STATUS_SUCCESS);
 
         // replace executor with warning executor
         self::$kernel->getContainer()->set('syrup.job_executor', new WarningExecutor());
 
-        $jobId = $jobManager->indexJob($this->createJob($encryptedToken));
+        $job = $jobManager->indexJob($this->createJob($encryptedToken));
 
         $this->application->find('syrup:run-job');
         $commandTester = new CommandTester($command);
         $commandTester->execute(
             array(
-                'jobId'   => $jobId
+                'jobId'   => $job->getId()
             )
         );
 
         $this->assertEquals(0, $commandTester->getStatusCode());
 
-        $job = $jobManager->getJob($jobId);
+        $job = $jobManager->getJob($job->getId());
         $this->assertNotNull($job);
         $this->assertArrayHasKey('testing', $job->getResult());
         $this->assertEquals($job->getStatus(), Job::STATUS_WARNING);
@@ -80,19 +80,19 @@ class JobCommandTest extends WebTestCase
         // replace executor with success executor
         self::$kernel->getContainer()->set('syrup.job_executor', new SuccessExecutor());
 
-        $jobId = $jobManager->indexJob($this->createJob($encryptedToken));
+        $job = $jobManager->indexJob($this->createJob($encryptedToken));
 
         $this->application->find('syrup:run-job');
         $commandTester = new CommandTester($command);
         $commandTester->execute(
             array(
-                'jobId'   => $jobId
+                'jobId'   => $job->getId()
             )
         );
 
         $this->assertEquals(0, $commandTester->getStatusCode());
 
-        $job = $jobManager->getJob($jobId);
+        $job = $jobManager->getJob($job->getId());
         $this->assertNotNull($job);
         $this->assertArrayHasKey('testing', $job->getResult());
         $this->assertEquals($job->getStatus(), Job::STATUS_SUCCESS);
@@ -100,19 +100,19 @@ class JobCommandTest extends WebTestCase
         // replace executor with error executor
         self::$kernel->getContainer()->set('syrup.job_executor', new ErrorExecutor());
 
-        $jobId = $jobManager->indexJob($this->createJob($encryptedToken));
+        $job = $jobManager->indexJob($this->createJob($encryptedToken));
 
         $this->application->find('syrup:run-job');
         $commandTester = new CommandTester($command);
         $commandTester->execute(
             array(
-                'jobId'   => $jobId
+                'jobId'   => $job->getId()
             )
         );
 
         $this->assertEquals(0, $commandTester->getStatusCode());
 
-        $job = $jobManager->getJob($jobId);
+        $job = $jobManager->getJob($job->getId());
         $this->assertNotNull($job);
         $this->assertArrayHasKey('testing', $job->getResult());
         $this->assertEquals($job->getStatus(), Job::STATUS_ERROR);
@@ -128,19 +128,19 @@ class JobCommandTest extends WebTestCase
         self::$kernel->getContainer()->set('syrup.job_executor', new HookExecutor($jobManager));
 
         // job execution test
-        $jobId = $jobManager->indexJob($this->createJob($encryptedToken));
+        $job = $jobManager->indexJob($this->createJob($encryptedToken));
 
         $command = $this->application->find('syrup:run-job');
         $commandTester = new CommandTester($command);
         $commandTester->execute(
             array(
-                'jobId'   => $jobId
+                'jobId'   => $job->getId()
             )
         );
 
         $this->assertEquals(0, $commandTester->getStatusCode());
 
-        $job = $jobManager->getJob($jobId);
+        $job = $jobManager->getJob($job->getId());
 
         $result = $job->getResult();
 

--- a/tests/Keboola/Syrup/Command/JobCommandTest.php
+++ b/tests/Keboola/Syrup/Command/JobCommandTest.php
@@ -6,6 +6,7 @@
  */
 namespace Keboola\Syrup\Tests\Command;
 
+use Keboola\StorageApi\Client as StorageApiClient;
 use Keboola\Syrup\Test\Job\Executor\ErrorExecutor;
 use Keboola\Syrup\Test\Job\Executor\HookExecutor;
 use Keboola\Syrup\Test\Job\Executor\SuccessExecutor;
@@ -20,10 +21,13 @@ use Keboola\Syrup\Tests\Job as TestExecutor;
 
 class JobCommandTest extends WebTestCase
 {
-    /**
-     * @var Application
-     */
+    /** @var Application */
     protected $application;
+
+    /** @var StorageApiClient */
+    protected $storageApiClient;
+
+    protected $storageApiToken;
 
     protected function setUp()
     {
@@ -31,14 +35,19 @@ class JobCommandTest extends WebTestCase
 
         $this->application = new Application(self::$kernel);
         $this->application->add(new JobCommand());
+
+        $this->storageApiToken = self::$kernel->getContainer()->getParameter('storage_api.test.token');
+        $this->storageApiClient = new StorageApiClient([
+            'token' => $this->storageApiToken,
+            'url' => self::$kernel->getContainer()->getParameter('storage_api.test.url')
+        ]);
     }
 
     public function testRunjob()
     {
         /** @var JobManager $jobManager */
         $jobManager = self::$kernel->getContainer()->get('syrup.job_manager');
-        $encryptedToken = self::$kernel->getContainer()->get('syrup.encryptor')
-            ->encrypt(self::$kernel->getContainer()->getParameter('storage_api.test.token'));
+        $encryptedToken = self::$kernel->getContainer()->get('syrup.encryptor')->encrypt($this->storageApiToken);
 
         // job execution test
         $job = $jobManager->indexJob($this->createJob($encryptedToken));
@@ -153,8 +162,8 @@ class JobCommandTest extends WebTestCase
     protected function createJob($token)
     {
         return new Job([
-            'id' => rand(0, 128),
-            'runId' => rand(0, 128),
+            'id' => $this->storageApiClient->generateId(),
+            'runId' => $this->storageApiClient->generateRunId(),
             'project' => [
                 'id' => '123',
                 'name' => 'Syrup TEST'

--- a/tests/Keboola/Syrup/Job/JobManagerTest.php
+++ b/tests/Keboola/Syrup/Job/JobManagerTest.php
@@ -104,42 +104,34 @@ class JobManagerTest extends WebTestCase
     public function testIndexJob()
     {
         $job = $this->createJob();
-        $id = self::$jobManager->indexJob($job);
+        $job = self::$jobManager->indexJob($job);
 
         $res = self::$elasticClient->get(array(
             'index' => self::$jobManager->getIndexCurrent(),
-            'type'  => 'jobs',
-            'id'    => $id
+            'type' => 'jobs',
+            'id' => $job->getId()
         ));
 
-        $resJob = $res['_source'];
+        $this->assertEquals($job->getVersion(), $res['_version']);
 
+        $resJob = $res['_source'];
         $this->assertJob($job, $resJob);
     }
 
     public function testUpdateJob()
     {
         $newJob = $this->createJob();
+        $newJob = self::$jobManager->indexJob($newJob);
 
-        $id = self::$jobManager->indexJob($newJob);
-
-
-        $job = self::$jobManager->getJob($id);
-
+        $job = $newJob;
         $job->setStatus(Job::STATUS_CANCELLED);
+        $job = self::$jobManager->updateJob($job);
 
-        self::$jobManager->updateJob($job);
-
-        $job = self::$jobManager->getJob($id);
-
+        $this->assertEquals($newJob->getVersion()+1, $job->getVersion());
         $this->assertEquals($job->getStatus(), Job::STATUS_CANCELLED);
 
-
         $job->setStatus(Job::STATUS_WARNING);
-
-        self::$jobManager->updateJob($job);
-
-        $job = self::$jobManager->getJob($id);
+        $job = self::$jobManager->updateJob($job);
 
         $this->assertEquals($job->getStatus(), Job::STATUS_WARNING);
     }
@@ -147,9 +139,9 @@ class JobManagerTest extends WebTestCase
     public function testGetJob()
     {
         $job = $this->createJob();
-        $id = self::$jobManager->indexJob($job);
+        $jobId = self::$jobManager->indexJob($job)->getId();
 
-        $resJob = self::$jobManager->getJob($id);
+        $resJob = self::$jobManager->getJob($jobId);
 
         $this->assertJob($job, $resJob->getData());
     }
@@ -160,7 +152,7 @@ class JobManagerTest extends WebTestCase
     public function testGetJobWithComponent()
     {
         $job = $this->createJob();
-        $id = self::$jobManager->indexJob($job);
+        $id = self::$jobManager->indexJob($job)->getId();
 
         $resJob = self::$jobManager->getJob($id, SYRUP_APP_NAME);
 

--- a/tests/Keboola/Syrup/Job/JobManagerTest.php
+++ b/tests/Keboola/Syrup/Job/JobManagerTest.php
@@ -162,7 +162,7 @@ class JobManagerTest extends WebTestCase
         $job = $this->createJob();
         $id = self::$jobManager->indexJob($job);
 
-        $resJob = self::$jobManager->getJob($id, 'syrup');
+        $resJob = self::$jobManager->getJob($id, SYRUP_APP_NAME);
 
         $this->assertJob($job, $resJob->getData());
     }


### PR DESCRIPTION
Musel som este raz prerobit veci ohladom JobManagera. A su to nekompatibilne zmeny. Kedze som do triedy Job musel pridat $version, tym padom aj do JobInterface a tak. Hlavne ide o to, ze indexJob() a updateJob() teraz vracaju Job objekt, je to preto, ze tento objekt ma v sebe aj verziu takze sa s tym lepsie pracuje.

Je to sice nekompatibilna uprava, ale vo velkej vacsine komponent nebude treba nic upravovat.

Okrem veci okolo JobManagera je este upraveny JobCommandTest, kde sa uplne debilne vytvarali joby s IDckami od 0 - 128 co robilo uplne haluze potom. Kedze sa joby vyberaju napriec indexami bol to uplny bordel.

Chcelo by to mergnut co najskor, aby sme sa zbavili tych "corrupted" messages.