### PR TITLE
fix: make error handlers immune to invalid storage token

### DIFF
--- a/src/Keboola/Syrup/Monolog/Handler/StorageApiHandler.php
+++ b/src/Keboola/Syrup/Monolog/Handler/StorageApiHandler.php
@@ -9,6 +9,7 @@ namespace Keboola\Syrup\Monolog\Handler;
 
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\Event;
+use Keboola\StorageApi\Exception as SapiException;
 use Monolog\Logger;
 use Keboola\Syrup\Exception\NoRequestException;
 use Keboola\Syrup\Exception\UserException;
@@ -31,6 +32,8 @@ class StorageApiHandler extends \Monolog\Handler\AbstractHandler
             // Ignore when no SAPI client setup
         } catch (UserException $e) {
             // Ignore when no SAPI client setup
+        } catch (SapiException $e) {
+            // Ignore when SAPI client setup is wrong
         }
     }
 

--- a/src/Keboola/Syrup/Monolog/Processor/SyslogProcessor.php
+++ b/src/Keboola/Syrup/Monolog/Processor/SyslogProcessor.php
@@ -2,6 +2,7 @@
 
 namespace Keboola\Syrup\Monolog\Processor;
 
+use Keboola\StorageApi\Exception as SapiException;
 use Keboola\Syrup\Debug\Exception\FlattenException;
 use Keboola\Syrup\Debug\ExceptionHandler;
 use Keboola\Syrup\Aws\S3\Uploader;
@@ -33,6 +34,7 @@ class SyslogProcessor
             $this->tokenData = $storageApiClient->getLogData();
             $this->runId = $storageApiClient->getRunId();
         } catch (SyrupComponentException $e) {
+        } catch (SapiException $e) {
         }
     }
 

--- a/tests/Keboola/Syrup/Monolog/Handler/StorageApiHandlerTest.php
+++ b/tests/Keboola/Syrup/Monolog/Handler/StorageApiHandlerTest.php
@@ -237,6 +237,14 @@ class StorageApiHandlerTest extends TestCase
         $this->assertEquals('', $event['description']);
     }
 
+    public function testInitInvalidToken()
+    {
+        $request = new Request();
+        $request->headers->add(['x-storageapi-token' => 'invalid']);
+        $storageApiService = new StorageApiService();
+        $storageApiService->setRequest($request);
+        new StorageApiHandler(SYRUP_APP_NAME, $storageApiService);
+    }
 
     private function initHandlerAndClient()
     {

--- a/tests/Keboola/Syrup/Monolog/Processor/SyslogProcessorTest.php
+++ b/tests/Keboola/Syrup/Monolog/Processor/SyslogProcessorTest.php
@@ -75,4 +75,23 @@ class SyslogProcessorTest extends TestCase
         $this->assertArrayHasKey('component', $newRecord);
         $this->assertEquals('fooBar', $newRecord['component']);
     }
+
+    public function testProcessorInitInvalidToken()
+    {
+        $s3Uploader = new Uploader([
+            'aws-access-key' => SYRUP_AWS_KEY,
+            'aws-secret-key' => SYRUP_AWS_SECRET,
+            'aws-region' => SYRUP_AWS_REGION,
+            's3-upload-path' => SYRUP_S3_BUCKET
+        ]);
+
+        $request = new Request();
+        $request->headers->add(['x-storageapi-token' => 'invalid']);
+        $storageApiService = new StorageApiService();
+        $storageApiService->setRequest($request);
+
+        $record = $this->getRecord();
+        $record['component'] = 'fooBar';
+        new SyslogProcessor(SYRUP_APP_NAME, $storageApiService, $s3Uploader);
+    }
 }


### PR DESCRIPTION
so that invalid token does NOT cause errors during application initialization and therefore ApplicationError
