### PR TITLE
Job - internal error inconsistent state

### DIFF
--- a/src/Keboola/Syrup/Command/JobCommand.php
+++ b/src/Keboola/Syrup/Command/JobCommand.php
@@ -223,7 +223,6 @@ class JobCommand extends ContainerAwareCommand
             $this->job->setStatus($jobStatus);
             $this->job->setResult($jobResult);
             $this->job->setError(Job::ERROR_APPLICATION);
-            $this->jobMapper->update($this->job);
 
             // try to log the exception
             $exceptionId = $this->logException('critical', $e);


### PR DESCRIPTION
Job status is updated before endTime, duration, result and other properties are set. 

https://github.com/keboola/syrup/blob/86d39c303166e9af9acd4489aff416672c0f7143/src/Keboola/Syrup/Command/JobCommand.php#L226


These properties are set few lines later https://github.com/keboola/syrup/blob/86d39c303166e9af9acd4489aff416672c0f7143/src/Keboola/Syrup/Command/JobCommand.php#L247