### PR TITLE
runId handling changed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 script:
   - ./bin/phpcs --standard=psr2 -n src tests
 #  - ./bin/phpmd src/ text codesize,unusedcode,naming,phpmd.xml
-  - ./bin/phpunit
+  - ./bin/phpunit --debug
 after_script:
   - ./codeclimate.sh
 notifications:

--- a/src/Keboola/Syrup/Job/Metadata/JobFactory.php
+++ b/src/Keboola/Syrup/Job/Metadata/JobFactory.php
@@ -51,7 +51,7 @@ class JobFactory
         $tokenData = $this->storageApiClient->verifyToken();
         $job = new Job($this->configEncryptor, [
                 'id' => $this->storageApiClient->generateId(),
-                'runId' => $this->storageApiClient->getRunId(),
+                'runId' => $this->storageApiClient->generateRunId($this->storageApiClient->getRunId()),
                 'project' => [
                     'id' => $tokenData['owner']['id'],
                     'name' => $tokenData['owner']['name']

--- a/src/Keboola/Syrup/Service/StorageApi/StorageApiService.php
+++ b/src/Keboola/Syrup/Service/StorageApi/StorageApiService.php
@@ -98,12 +98,9 @@ class StorageApiService
             ]));
 
             if ($request->headers->has('X-KBC-RunId')) {
-                $kbcRunId = $this->client->generateRunId($request->headers->get('X-KBC-RunId'));
-            } else {
-                $kbcRunId = $this->client->generateRunId();
+                $this->client->setRunId($request->headers->get('X-KBC-RunId'));
             }
 
-            $this->client->setRunId($kbcRunId);
         }
 
         return $this->client;

--- a/tests/Keboola/Syrup/Monolog/Handler/StorageApiHandlerTest.php
+++ b/tests/Keboola/Syrup/Monolog/Handler/StorageApiHandlerTest.php
@@ -259,6 +259,7 @@ class StorageApiHandlerTest extends TestCase
         $requestStack->push($request);
         $storageApiService = new StorageApiService('https://connection.keboola.com', $requestStack);
         $client = $storageApiService->getClient();
+        $client->setRunId(uniqid());
         $handler = new StorageApiHandler(SYRUP_APP_NAME, $storageApiService);
         return [$client, $handler];
     }

--- a/tests/Keboola/Syrup/Monolog/Handler/StorageApiHandlerTest.php
+++ b/tests/Keboola/Syrup/Monolog/Handler/StorageApiHandlerTest.php
@@ -35,6 +35,7 @@ class StorageApiHandlerTest extends TestCase
 
         $storageApiService = new StorageApiService('https://connection.keboola.com', $requestStack);
         $client = $storageApiService->getClient();
+        $client->setRunId(uniqid());
         $events = $client->listEvents(['q' => 'message: infoMessage + runId:' . $client->getRunId()]);
         // nothing is logged, because SAPI client was not initialized
         $this->assertEquals(0, count($events));


### PR DESCRIPTION
Generovani noveho runId  se takhle volalo pri kazdem callu na syrup napr. getJob. coz je vlastne zbytecny, ten jeden API call na sapi je znat.
Myslim ze takhle by to melo snad byt ok, nove runId to vygeneruje az pro nove zalozeny job.