### PR TITLE
Refactor objectencryptor

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -101,7 +101,7 @@ services:
 
     syrup.job_factory:
         class: Keboola\Syrup\Job\Metadata\JobFactory
-        arguments: [%app_name%, @syrup.encryptor, @syrup.object_encryptor, @syrup.storage_api]
+        arguments: [%app_name%, @syrup.object_encryptor, @syrup.storage_api]
 
     syrup.job_executor:
         class: Keboola\Syrup\Job\Executor
@@ -112,3 +112,4 @@ services:
 
     syrup.object_encryptor:
         class: Keboola\Syrup\Service\ObjectEncryptor
+        arguments: [@syrup.encryptor]

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -112,4 +112,3 @@ services:
 
     syrup.object_encryptor:
         class: Keboola\Syrup\Service\ObjectEncryptor
-        arguments: [@service_container]

--- a/src/Keboola/Syrup/Command/JobCleanupCommand.php
+++ b/src/Keboola/Syrup/Command/JobCleanupCommand.php
@@ -15,6 +15,7 @@ use Keboola\Syrup\Job\ExecutorFactory;
 use Keboola\Syrup\Job\ExecutorInterface;
 use Keboola\Syrup\Job\Metadata\Job;
 use Keboola\Syrup\Service\Db\Lock;
+use Keboola\Syrup\Service\ObjectEncryptor;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -56,8 +57,8 @@ class JobCleanupCommand extends ContainerAwareCommand
         }
 
         // SAPI init
-        /** @var EncryptorInterface $encryptor */
-        $encryptor = $this->getContainer()->get('syrup.encryptor');
+        /** @var ObjectEncryptor $encryptor */
+        $encryptor = $this->getContainer()->get('syrup.object_encryptor');
 
         $this->sapiClient = new SapiClient([
             'token' => $encryptor->decrypt($this->job->getToken()['token']),

--- a/src/Keboola/Syrup/Command/JobCommand.php
+++ b/src/Keboola/Syrup/Command/JobCommand.php
@@ -13,6 +13,7 @@ use Keboola\Encryption\EncryptorInterface;
 use Keboola\Syrup\Elasticsearch\Search;
 use Keboola\Syrup\Exception\MaintenanceException;
 use Keboola\Syrup\Job\ExecutorFactory;
+use Keboola\Syrup\Service\ObjectEncryptor;
 use Keboola\Syrup\Service\StorageApi\Limits;
 use Monolog\Logger;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
@@ -79,8 +80,8 @@ class JobCommand extends ContainerAwareCommand
         }
 
         // SAPI init
-        /** @var EncryptorInterface $encryptor */
-        $encryptor = $this->getContainer()->get('syrup.encryptor');
+        /** @var ObjectEncryptor $encryptor */
+        $encryptor = $this->getContainer()->get('syrup.object_encryptor');
 
         $this->sapiClient = new SapiClient([
             'token' => $encryptor->decrypt($this->job->getToken()['token']),

--- a/src/Keboola/Syrup/Controller/ApiController.php
+++ b/src/Keboola/Syrup/Controller/ApiController.php
@@ -158,6 +158,7 @@ class ApiController extends BaseController
      */
     protected function createJob($command, $params)
     {
+        /** @var JobFactory $jobFactory */
         $jobFactory = $this->container->get('syrup.job_factory');
         $jobFactory->setStorageApiClient($this->storageApi);
         return $jobFactory->create($command, $params);

--- a/src/Keboola/Syrup/Encryption/Encryptor.php
+++ b/src/Keboola/Syrup/Encryption/Encryptor.php
@@ -10,6 +10,11 @@ namespace Keboola\Syrup\Encryption;
 use Keboola\Encryption\AesEncryptor;
 use Keboola\Encryption\EncryptorInterface;
 
+/**
+ * Class Encryptor
+ * @package Keboola\Syrup\Encryption
+ * @deprecated Use ObjectEncryptor service
+ */
 class Encryptor implements EncryptorInterface
 {
     /** @var AesEncryptor */
@@ -23,6 +28,7 @@ class Encryptor implements EncryptorInterface
     /**
      * @param $data string data to encrypt
      * @return string encrypted data
+     * @deprecated
      */
     public function encrypt($data)
     {
@@ -32,6 +38,7 @@ class Encryptor implements EncryptorInterface
     /**
      * @param $encryptedData string
      * @return string decrypted data
+     * @deprecated
      */
     public function decrypt($encryptedData)
     {

--- a/src/Keboola/Syrup/Job/Metadata/JobFactory.php
+++ b/src/Keboola/Syrup/Job/Metadata/JobFactory.php
@@ -14,11 +14,8 @@ use Keboola\Syrup\Service\StorageApi\StorageApiService;
 
 class JobFactory
 {
-    /* @var Encryptor */
-    protected $encryptor;
-
     /* @var ObjectEncryptor */
-    protected $configEncryptor;
+    protected $objectEncryptor;
 
     protected $componentName;
 
@@ -32,12 +29,10 @@ class JobFactory
 
     public function __construct(
         $componentName,
-        Encryptor $encryptor,
-        ObjectEncryptor $configEncryptor,
+        ObjectEncryptor $objectEncryptor,
         StorageApiService $storageApiService = null
     ) {
-        $this->encryptor = $encryptor;
-        $this->configEncryptor = $configEncryptor;
+        $this->objectEncryptor = $objectEncryptor;
         $this->componentName = $componentName;
         $this->storageApiService = $storageApiService;
     }
@@ -61,7 +56,7 @@ class JobFactory
             $tokenData = $this->storageApiClient->verifyToken();
         }
 
-        $job = new Job($this->configEncryptor, [
+        $job = new Job($this->objectEncryptor, [
                 'id' => $this->storageApiClient->generateId(),
                 'runId' => $this->storageApiClient->generateRunId($this->storageApiClient->getRunId()),
                 'project' => [
@@ -71,7 +66,7 @@ class JobFactory
                 'token' => [
                     'id' => $tokenData['id'],
                     'description' => $tokenData['description'],
-                    'token' => $this->encryptor->encrypt($this->storageApiClient->getTokenString())
+                    'token' => $this->objectEncryptor->encrypt($this->storageApiClient->getTokenString())
                 ],
                 'component' => $this->componentName,
                 'command' => $command,

--- a/src/Keboola/Syrup/Service/ObjectEncryptor.php
+++ b/src/Keboola/Syrup/Service/ObjectEncryptor.php
@@ -130,7 +130,9 @@ class ObjectEncryptor
         $wrapper = $this->findWrapper($value);
         if (!$wrapper) {
             if ($this->legacyEncryptor) {
-                $ret = $this->legacyEncryptor->decrypt($value);
+                /* @ is intentional to suppress warnings from invalid cipher texts which
+                 are handled by checking return === false */
+                $ret = @$this->legacyEncryptor->decrypt($value);
                 if ($ret === false) {
                     throw new \InvalidCiphertextException("Value is not an encrypted value.");
                 } else {

--- a/src/Keboola/Syrup/Test/Monolog/TestCase.php
+++ b/src/Keboola/Syrup/Test/Monolog/TestCase.php
@@ -8,9 +8,8 @@
 namespace Keboola\Syrup\Test\Monolog;
 
 use Monolog\Logger;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
-class TestCase extends KernelTestCase
+class TestCase extends \PHPUnit_Framework_TestCase
 {
 
     protected function getRecord($level = Logger::WARNING, $message = 'test', $context = array())

--- a/tests/Keboola/Syrup/Elasticsearch/JobMapperTest.php
+++ b/tests/Keboola/Syrup/Elasticsearch/JobMapperTest.php
@@ -47,7 +47,7 @@ class JobMapperTest extends KernelTestCase
         /** @var StorageApiService $storageApiService */
         $storageApiService = self::$kernel->getContainer()->get('syrup.storage_api');
         $storageApiService->setClient(new \Keboola\StorageApi\Client(['token' => SYRUP_SAPI_TEST_TOKEN]));
-        self::$jobFactory = new JobFactory(SYRUP_APP_NAME, new Encryptor(md5(uniqid())), $configEncryptor, $storageApiService);
+        self::$jobFactory = new JobFactory(SYRUP_APP_NAME, $configEncryptor, $storageApiService);
         self::$jobMapper = new JobMapper(self::$client, self::$index, $configEncryptor, null, realpath(__DIR__ . '/../../../../app'));
     }
 

--- a/tests/Keboola/Syrup/Elasticsearch/SearchTest.php
+++ b/tests/Keboola/Syrup/Elasticsearch/SearchTest.php
@@ -7,7 +7,6 @@
 namespace Keboola\Syrup\Tests\Elasticsearch;
 
 use Elasticsearch\Client as ElasticClient;
-use Keboola\Encryption\EncryptorInterface;
 use Keboola\StorageApi\Client as SapiClient;
 use Keboola\Syrup\Elasticsearch\ComponentIndex;
 use Keboola\Syrup\Elasticsearch\Search;
@@ -24,13 +23,12 @@ class SearchTest extends WebTestCase
     /** @var SapiClient */
     protected static $sapiClient;
 
-    /** @var EncryptorInterface */
-    protected static $encryptor;
-
     /** @var ElasticClient */
     protected static $elasticClient;
+
     /** @var ComponentIndex */
     protected static $index;
+
     /** @var JobMapper */
     protected static $jobMapper;
 
@@ -55,8 +53,6 @@ class SearchTest extends WebTestCase
             'url' => self::$kernel->getContainer()->getParameter('storage_api.test.url'),
             'userAgent' => SYRUP_APP_NAME,
         ]);
-
-        self::$encryptor = self::$kernel->getContainer()->get('syrup.encryptor');
 
         // clear data
         $sapiData = self::$sapiClient->getLogData();
@@ -87,7 +83,7 @@ class SearchTest extends WebTestCase
                 'token'     => [
                     'id'            => $tokenData['id'],
                     'description'   => $tokenData['description'],
-                    'token'         => self::$encryptor->encrypt(self::$sapiClient->getTokenString())
+                    'token'         => $configEncryptor->encrypt(self::$sapiClient->getTokenString())
                 ],
                 'component' => SYRUP_APP_NAME,
                 'command'   => 'run',

--- a/tests/Keboola/Syrup/Job/Metadata/JobFactoryTest.php
+++ b/tests/Keboola/Syrup/Job/Metadata/JobFactoryTest.php
@@ -7,7 +7,6 @@
 namespace Keboola\Syrup\Tests\Job\Metadata;
 
 use Keboola\StorageApi\Client;
-use Keboola\Syrup\Encryption\Encryptor;
 use Keboola\Syrup\Job\Metadata\JobFactory;
 use Keboola\Syrup\Service\ObjectEncryptor;
 use Keboola\Syrup\Service\StorageApi\StorageApiService;
@@ -20,6 +19,7 @@ class JobFactoryTest extends KernelTestCase
         static::bootKernel();
     }
 
+
     /**
      * @covers \Keboola\Syrup\Job\Metadata\JobFactory::create
      * @covers \Keboola\Syrup\Job\Metadata\JobFactory::setStorageApiClient
@@ -31,14 +31,12 @@ class JobFactoryTest extends KernelTestCase
             'userAgent' => SYRUP_APP_NAME,
         ]);
 
-        $key = md5(uniqid());
-        $encryptor = new Encryptor($key);
-        /** @var ObjectEncryptor $configEncryptor */
-        $configEncryptor = self::$kernel->getContainer()->get('syrup.object_encryptor');
+        /** @var ObjectEncryptor $encryptor */
+        $encryptor = self::$kernel->getContainer()->get('syrup.object_encryptor');
         /** @var StorageApiService $storageApiService */
         $storageApiService = self::$kernel->getContainer()->get('syrup.storage_api');
         $storageApiService->setClient($storageApiClient);
-        $jobFactory = new JobFactory(SYRUP_APP_NAME, $encryptor, $configEncryptor, $storageApiService);
+        $jobFactory = new JobFactory(SYRUP_APP_NAME, $encryptor, $storageApiService);
 
         $command = uniqid();
         $param = uniqid();

--- a/tests/Keboola/Syrup/Job/Metadata/JobTest.php
+++ b/tests/Keboola/Syrup/Job/Metadata/JobTest.php
@@ -7,7 +7,6 @@
 namespace Keboola\Syrup\Tests\Job\Metadata;
 
 use Keboola\StorageApi\Client;
-use Keboola\Syrup\Encryption\BaseWrapper;
 use Keboola\Syrup\Encryption\Encryptor;
 use Keboola\Syrup\Job\Metadata\JobFactory;
 use Keboola\Syrup\Service\ObjectEncryptor;

--- a/tests/Keboola/Syrup/Job/Metadata/JobTest.php
+++ b/tests/Keboola/Syrup/Job/Metadata/JobTest.php
@@ -7,7 +7,6 @@
 namespace Keboola\Syrup\Tests\Job\Metadata;
 
 use Keboola\StorageApi\Client;
-use Keboola\Syrup\Encryption\Encryptor;
 use Keboola\Syrup\Job\Metadata\JobFactory;
 use Keboola\Syrup\Service\ObjectEncryptor;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -30,17 +29,15 @@ class JobTest extends KernelTestCase
             'userAgent' => SYRUP_APP_NAME,
         ]));
 
-        $key = md5(uniqid());
-        $encryptor = new Encryptor($key);
-        /** @var ObjectEncryptor $configEncryptor */
-        $configEncryptor = self::$kernel->getContainer()->get('syrup.object_encryptor');
-        $jobFactory = new JobFactory(SYRUP_APP_NAME, $encryptor, $configEncryptor, $storageApiService);
+        /** @var ObjectEncryptor $objectEncryptor */
+        $objectEncryptor = self::$kernel->getContainer()->get('syrup.object_encryptor');
+        $jobFactory = new JobFactory(SYRUP_APP_NAME, $objectEncryptor, $storageApiService);
 
         $command = uniqid();
         $param = ["key1" => "value1", "#key2" => "value2"];
         $lock = uniqid();
 
-        $job = $jobFactory->create($command, $configEncryptor->encrypt($param), $lock);
+        $job = $jobFactory->create($command, $objectEncryptor->encrypt($param), $lock);
         $job->setEncrypted(true);
 
         $this->assertEquals($command, $job->getCommand());

--- a/tests/Keboola/Syrup/Monolog/Processor/JobProcessorTest.php
+++ b/tests/Keboola/Syrup/Monolog/Processor/JobProcessorTest.php
@@ -15,12 +15,6 @@ use Keboola\Syrup\Test\Monolog\TestCase;
 
 class JobProcessorTest extends TestCase
 {
-
-    public function setUp()
-    {
-        static::bootKernel();
-    }
-
     /**
      * @covers \Keboola\Syrup\Monolog\Processor\JobProcessor::__invoke
      * @covers \Keboola\Syrup\Monolog\Processor\JobProcessor::processRecord
@@ -29,8 +23,8 @@ class JobProcessorTest extends TestCase
     public function testProcessor()
     {
         $processor = new JobProcessor();
-        /** @var ObjectEncryptor $configEncryptor */
-        $configEncryptor = self::$kernel->getContainer()->get('syrup.object_encryptor');
+        $configEncryptor = new ObjectEncryptor();
+        $configEncryptor->pushWrapper(new BaseWrapper(uniqid('fooBar')));
         $processor->setJob(new Job($configEncryptor, [
                 'id' => uniqid(),
                 'runId' => uniqid(),

--- a/tests/Keboola/Syrup/Monolog/Processor/SyslogProcessorTest.php
+++ b/tests/Keboola/Syrup/Monolog/Processor/SyslogProcessorTest.php
@@ -8,6 +8,7 @@
 namespace Keboola\Syrup\Tests\Monolog\Processor;
 
 use Keboola\Syrup\Aws\S3\Uploader;
+use Keboola\Syrup\Encryption\BaseWrapper;
 use Keboola\Syrup\Job\Metadata\Job;
 use Keboola\Syrup\Monolog\Processor\JobProcessor;
 use Keboola\Syrup\Monolog\Processor\RequestProcessor;
@@ -21,11 +22,6 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class SyslogProcessorTest extends TestCase
 {
-    public function setUp()
-    {
-        static::bootKernel();
-    }
-
     private function getSysLogProcessor()
     {
         $s3Uploader = new Uploader([
@@ -191,8 +187,8 @@ class SyslogProcessorTest extends TestCase
     public function testJobLong()
     {
         $processor = new JobProcessor();
-        /** @var ObjectEncryptor $configEncryptor */
-        $configEncryptor = self::$kernel->getContainer()->get('syrup.object_encryptor');
+        $configEncryptor = new ObjectEncryptor();
+        $configEncryptor->pushWrapper(new BaseWrapper(uniqid('foobar')));
         $jobId = intval(uniqid());
         $processor->setJob(new Job($configEncryptor, [
             'id' => $jobId,

--- a/tests/Keboola/Syrup/Service/ObjectEncryptorTest.php
+++ b/tests/Keboola/Syrup/Service/ObjectEncryptorTest.php
@@ -895,4 +895,18 @@ class ObjectEncryptorTest extends WebTestCase
         $this->assertNotEquals($originalText, $encrypted);
         $this->assertEquals($originalText, $encryptor->decrypt($encrypted));
     }
+
+    public function testEncryptorLegacyFail()
+    {
+        $client = static::createClient();
+        $encryptor = $client->getContainer()->get('syrup.object_encryptor');
+
+        $originalText = 'test';
+        try {
+            $encryptor->decrypt($originalText);
+            $this->fail("Invalid cipher must fail.");
+        } catch (UserException $e) {
+            $this->assertContains('is not an encrypted value', $e->getMessage());
+        }
+    }
 }

--- a/tests/Keboola/Syrup/Service/ObjectEncryptorTest.php
+++ b/tests/Keboola/Syrup/Service/ObjectEncryptorTest.php
@@ -205,11 +205,10 @@ class ObjectEncryptorTest extends WebTestCase
         /** @var ObjectEncryptor $encryptor */
         $encryptor = $client->getContainer()->get('syrup.object_encryptor');
         $wrapper = new MockCryptoWrapper();
-        $client->getContainer()->set('mock.crypto.wrapper', $wrapper);
         $encryptor->pushWrapper($wrapper);
 
         $secret = 'secret';
-        $encryptedValue = $encryptor->encrypt($secret, 'mock.crypto.wrapper');
+        $encryptedValue = $encryptor->encrypt($secret, MockCryptoWrapper::class);
         $this->assertEquals("KBC::MockCryptoWrapper==" . $secret, $encryptedValue);
 
         $encryptedSecond = $encryptor->encrypt($encryptedValue);
@@ -739,12 +738,11 @@ class ObjectEncryptorTest extends WebTestCase
          */
         $encryptor = $client->getContainer()->get('syrup.object_encryptor');
         $wrapper = new AnotherCryptoWrapper(md5(uniqid()));
-        $client->getContainer()->set('another.crypto.wrapper', $wrapper);
         $encryptor->pushWrapper($wrapper);
 
         $array = [
             "#key1" => $encryptor->encrypt("value1"),
-            "#key2" => $encryptor->encrypt("value2", 'another.crypto.wrapper')
+            "#key2" => $encryptor->encrypt("value2", AnotherCryptoWrapper::class)
         ];
         $this->assertEquals("KBC::Encrypted==", substr($array["#key1"], 0, 16));
         $this->assertEquals("KBC::AnotherCryptoWrapper==", substr($array["#key2"], 0, 27));
@@ -810,8 +808,7 @@ class ObjectEncryptorTest extends WebTestCase
 
     public function testEncryptorNoWrappers()
     {
-        $client = static::createClient();
-        $encryptor = new ObjectEncryptor($client->getContainer());
+        $encryptor = new ObjectEncryptor();
         try {
             $encryptor->encrypt("test");
             $this->fail("Misconfigured object encryptor must raise exception.");


### PR DESCRIPTION
Migration:

`Keboola/Syrup/Encryption/Encryptor` je deprecated
Sifry vytvorene tridou `Encyptor` desifruje `ObjectEncryptor`
Vytvaret sifry tridou `Encyptor` nejde.

V constructoru
`Keboola\Syrup\Job\Metadata\JobFactory`
se rusi parametr `Encryptor $encryptor`,

Pri manulnim ziskavani encryptoru:

`$encryptor = $this->getContainer()->get('syrup.encryptor');`

nahrazuje service:

`$encryptor = $this->getContainer()->get('syrup.object_encryptor');`

Pri manualnim vytvareni object encryptoru se rusi parametr $container a je potreba mu pridat BaseWrapper
```
$encryptor = new ObjectEncryptor();
$encryptor->pushWrapper(new BaseWrapper(md5(uniqid())));
```
(pokud chybi druhy radek projevi se chybou "Invalid crypto wrapper Keboola\Syrup\Encryption\BaseWrapper")

V testech je timpadem mozny nahradit
```
class TestCase extends KernelTestCase
```
za
```
class TestCase extends \PHPUnit_Framework_TestCase
```
(pokud tam byl container jen kvuli encryptoru)
