### PR TITLE
fix: remove error message prefix

### DIFF
--- a/src/Keboola/Syrup/Exception/ApplicationException.php
+++ b/src/Keboola/Syrup/Exception/ApplicationException.php
@@ -11,6 +11,6 @@ class ApplicationException extends SyrupComponentException
 {
     public function __construct($message, $previous = null, array $data = [])
     {
-        parent::__construct(500, 'Application error: ' . $message, $previous, $data);
+        parent::__construct(500, $message, $previous, $data);
     }
 }


### PR DESCRIPTION
fixes https://github.com/keboola/docker-bundle/issues/354

Ale teda vůbec se mi nelíbí, že `\Keboola\DockerBundle\Exception\UserException` má `statusCode = 500`.