### PR TITLE
Log to php://stdout

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -11,9 +11,9 @@ monolog:
             type: console
             verbosity_levels:
                 VERBOSITY_NORMAL: EMERGENCY
-        syrup_syslog:
-            type: syslog
-            ident: %app_name%
+        syrup_stdout:
+            type: stream
+            path: "php://stdout"
             level: debug
             channels: ["!request", "!event", "!doctrine"]
             formatter: syrup.monolog.formatter

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -7,9 +7,9 @@ monolog:
             type: console
             verbosity_levels:
                 VERBOSITY_NORMAL: EMERGENCY
-        syrup_syslog:
-            type: syslog
-            ident: %app_name%
+        syrup_stdout:
+            type: stream
+            path: "php://stdout"
             level: info
             channels: ["!request", "!event", "!doctrine"]
             formatter: syrup.monolog.formatter

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -31,8 +31,8 @@ services:
     syrup.monolog.signal_handler:
         class: Keboola\Syrup\Monolog\Handler\SignalHandler
 
-    syrup.monolog.syslog_processor:
-        class: Keboola\Syrup\Monolog\Processor\SyslogProcessor
+    syrup.monolog.stdout_processor:
+        class: Keboola\Syrup\Monolog\Processor\StdoutProcessor
         arguments: ["%app_name%", "@syrup.storage_api", "@syrup.s3_uploader"]
         tags:
             - { name: monolog.processor, method: processRecord, handler: syrup_stdout }

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -35,7 +35,7 @@ services:
         class: Keboola\Syrup\Monolog\Processor\SyslogProcessor
         arguments: ["%app_name%", "@syrup.storage_api", "@syrup.s3_uploader"]
         tags:
-            - { name: monolog.processor, method: processRecord, handler: syrup_syslog }
+            - { name: monolog.processor, method: processRecord, handler: syrup_stdout }
 
     syrup.monolog.request_processor:
         class: Keboola\Syrup\Monolog\Processor\RequestProcessor

--- a/src/Keboola/Syrup/Command/JobCleanupCommand.php
+++ b/src/Keboola/Syrup/Command/JobCleanupCommand.php
@@ -73,8 +73,8 @@ class JobCleanupCommand extends ContainerAwareCommand
         $logProcessor = $this->getContainer()->get('syrup.monolog.job_processor');
         $logProcessor->setJob($this->job);
 
-        /** @var \Keboola\Syrup\Monolog\Processor\SyslogProcessor $logProcessor */
-        $logProcessor = $this->getContainer()->get('syrup.monolog.syslog_processor');
+        /** @var \Keboola\Syrup\Monolog\Processor\StdoutProcessor $logProcessor */
+        $logProcessor = $this->getContainer()->get('syrup.monolog.stdout_processor');
         $logProcessor->setRunId($this->job->getRunId());
         $logProcessor->setTokenData($storageApiService->getTokenData());
 

--- a/src/Keboola/Syrup/Command/JobCommand.php
+++ b/src/Keboola/Syrup/Command/JobCommand.php
@@ -100,8 +100,8 @@ class JobCommand extends ContainerAwareCommand
         $logProcessor = $this->getContainer()->get('syrup.monolog.job_processor');
         $logProcessor->setJob($this->job);
 
-        /** @var \Keboola\Syrup\Monolog\Processor\SyslogProcessor $logProcessor */
-        $logProcessor = $this->getContainer()->get('syrup.monolog.syslog_processor');
+        /** @var \Keboola\Syrup\Monolog\Processor\StdoutProcessor $logProcessor */
+        $logProcessor = $this->getContainer()->get('syrup.monolog.stdout_processor');
         $logProcessor->setRunId($this->job->getRunId());
         $logProcessor->setTokenData($storageApiService->getTokenData());
 

--- a/src/Keboola/Syrup/Debug/ExceptionHandler.php
+++ b/src/Keboola/Syrup/Debug/ExceptionHandler.php
@@ -23,17 +23,12 @@ class ExceptionHandler extends BaseExceptionHandler
     private $fileLinkFormat;
     protected $env;
 
-    private $logger;
-
     public function __construct($debug = true, $charset = 'UTF-8', $env = 'dev')
     {
         $this->env = $env;
         parent::__construct($debug);
         $this->debug = $debug;
         $this->fileLinkFormat = ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format');
-
-        $this->logger = new Logger('exception-handler');
-        $this->logger->pushHandler(new StreamHandler('php://stdout'));
     }
 
     /**
@@ -90,10 +85,12 @@ class ExceptionHandler extends BaseExceptionHandler
         ];
 
         // log to stdout
+        $logger = new Logger($appName);
+        $logger->pushHandler(new StreamHandler('php://stdout'));
         if ($priority === 'CRITICAL') {
-            $this->logger->addCritical(json_encode($logData));
+            $logger->addCritical(json_encode($logData));
         } else {
-            $this->logger->addError(json_encode($logData));
+            $logger->addError(json_encode($logData));
         }
 
         $response = [

--- a/src/Keboola/Syrup/Monolog/Processor/StdoutProcessor.php
+++ b/src/Keboola/Syrup/Monolog/Processor/StdoutProcessor.php
@@ -13,7 +13,7 @@ use Keboola\Syrup\Service\StorageApi\StorageApiService;
 /**
  * Injects info about component and used Storage Api token
  */
-class SyslogProcessor
+class StdoutProcessor
 {
 
     private $componentName;

--- a/tests/Keboola/Syrup/Debug/ErrorHandlingTest.php
+++ b/tests/Keboola/Syrup/Debug/ErrorHandlingTest.php
@@ -27,10 +27,10 @@ class ErrorHandlingTest extends WebTestCase
 
         $errorOccured = false;
 
-        $syslogProcessorMock = $this->getMockBuilder('Keboola\\Syrup\\Monolog\\Processor\\SyslogProcessor')
+        $stdoutProcessorMock = $this->getMockBuilder('Keboola\\Syrup\\Monolog\\Processor\\StdoutProcessor')
             ->disableOriginalConstructor()
             ->getMock();
-        $syslogProcessorMock->expects($this->any())
+        $stdoutProcessorMock->expects($this->any())
             ->method("processRecord")
             ->with($this->callback(function ($subject) use (&$errorOccured) {
                 if ($subject['message'] == 'Notice: Undefined offset: 3') {
@@ -45,7 +45,7 @@ class ErrorHandlingTest extends WebTestCase
             ]);
 
         $container = $this->client->getContainer();
-        $container->set('syrup.monolog.syslog_processor', $syslogProcessorMock);
+        $container->set('syrup.monolog.stdout_processor', $stdoutProcessorMock);
 
         $this->client->request('GET', '/tests/notice');
         $response = $this->client->getResponse();

--- a/tests/Keboola/Syrup/Listener/SyrupExceptionListenerTest.php
+++ b/tests/Keboola/Syrup/Listener/SyrupExceptionListenerTest.php
@@ -23,7 +23,7 @@ use Keboola\Syrup\Command\JobCommand;
 use Keboola\Syrup\Exception\UserException;
 use Keboola\Syrup\Listener\SyrupExceptionListener;
 use Keboola\Syrup\Monolog\Formatter\JsonFormatter;
-use Keboola\Syrup\Monolog\Processor\SyslogProcessor;
+use Keboola\Syrup\Monolog\Processor\StdoutProcessor;
 use Keboola\Syrup\Service\StorageApi\StorageApiService;
 
 class SyrupExceptionListenerTest extends KernelTestCase
@@ -58,7 +58,7 @@ class SyrupExceptionListenerTest extends KernelTestCase
         ]);
         $this->testLogHandler = new TestHandler();
         $this->testLogHandler->setFormatter(new JsonFormatter());
-        $this->testLogHandler->pushProcessor(new SyslogProcessor(SYRUP_APP_NAME, $storageApiService, $uploader));
+        $this->testLogHandler->pushProcessor(new StdoutProcessor(SYRUP_APP_NAME, $storageApiService, $uploader));
         $logger = new \Monolog\Logger('test', [$this->testLogHandler]);
         $this->listener = new SyrupExceptionListener(SYRUP_APP_NAME, $storageApiService, $logger);
     }
@@ -82,7 +82,7 @@ class SyrupExceptionListenerTest extends KernelTestCase
         ]);
         $testLogHandler = new TestHandler();
         $testLogHandler->setFormatter(new JsonFormatter());
-        $testLogHandler->pushProcessor(new SyslogProcessor(SYRUP_APP_NAME, $storageApiService, $uploader));
+        $testLogHandler->pushProcessor(new StdoutProcessor(SYRUP_APP_NAME, $storageApiService, $uploader));
         $logger = new \Monolog\Logger('test', [$testLogHandler]);
 
         $listener = new SyrupExceptionListener(SYRUP_APP_NAME, $storageApiService, $logger);

--- a/tests/Keboola/Syrup/Monolog/Processor/StdoutProcessorTest.php
+++ b/tests/Keboola/Syrup/Monolog/Processor/StdoutProcessorTest.php
@@ -15,14 +15,14 @@ use Keboola\Syrup\Monolog\Processor\JobProcessor;
 use Keboola\Syrup\Monolog\Processor\RequestProcessor;
 use Symfony\Bridge\Monolog\Logger;
 use Symfony\Component\HttpFoundation\Request;
-use Keboola\Syrup\Monolog\Processor\SyslogProcessor;
+use Keboola\Syrup\Monolog\Processor\StdoutProcessor;
 use Keboola\Syrup\Service\StorageApi\StorageApiService;
 use Keboola\Syrup\Test\Monolog\TestCase;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-class SyslogProcessorTest extends TestCase
+class StdoutProcessorTest extends TestCase
 {
-    private function getSysLogProcessor()
+    private function getStdoutProcessor()
     {
         $s3Uploader = new UploaderS3([
             'aws-access-key' => AWS_ACCESS_KEY_ID,
@@ -38,12 +38,12 @@ class SyslogProcessorTest extends TestCase
         $requestStack->push($request);
         $storageApiService = new StorageApiService($requestStack, SAPI_URL);
 
-        return new SyslogProcessor(SYRUP_APP_NAME, $storageApiService, $s3Uploader);
+        return new StdoutProcessor(SYRUP_APP_NAME, $storageApiService, $s3Uploader);
     }
 
     public function testProcessorTokenLong()
     {
-        $processor = $this->getSysLogProcessor();
+        $processor = $this->getStdoutProcessor();
         $record = $this->getRecord(Logger::WARNING, str_repeat('batman', 1000));
         $newRecord = $processor($record);
 
@@ -73,7 +73,7 @@ class SyslogProcessorTest extends TestCase
 
     public function testProcessorTokenShort()
     {
-        $processor = $this->getSysLogProcessor();
+        $processor = $this->getStdoutProcessor();
         $record = $this->getRecord(Logger::WARNING, 'batman');
         $newRecord = $processor($record);
 
@@ -120,7 +120,7 @@ class SyslogProcessorTest extends TestCase
 
         $record = $this->getRecord(Logger::WARNING, str_repeat('batman', 1000));
         // instantiation must not fail
-        $processor = new SyslogProcessor(SYRUP_APP_NAME, $storageApiService, $s3Uploader);
+        $processor = new StdoutProcessor(SYRUP_APP_NAME, $storageApiService, $s3Uploader);
         $newRecord = $processor($record);
 
         $this->assertEquals(7, count($newRecord));
@@ -165,7 +165,7 @@ class SyslogProcessorTest extends TestCase
         $processor = new RequestProcessor($requestStack, $s3Uploader);
         $record = $this->getRecord(Logger::WARNING, str_repeat('batman', 1000));
         $record = $processor($record);
-        $processor = $this->getSysLogProcessor();
+        $processor = $this->getStdoutProcessor();
         $newRecord = $processor($record);
 
         $this->assertEquals(10, count($newRecord));
@@ -204,7 +204,7 @@ class SyslogProcessorTest extends TestCase
         ], null, null, null));
         $record = $this->getRecord(Logger::WARNING, str_repeat('batman', 1000));
         $record = $processor($record);
-        $processor = $this->getSysLogProcessor();
+        $processor = $this->getStdoutProcessor();
         $newRecord = $processor($record);
 
         $this->assertEquals(9, count($newRecord));
@@ -226,7 +226,7 @@ class SyslogProcessorTest extends TestCase
 
     public function testProcessorExceptionLong()
     {
-        $processor = $this->getSysLogProcessor();
+        $processor = $this->getStdoutProcessor();
         $record = $this->getRecord(
             Logger::WARNING,
             str_repeat('batman', 1000),
@@ -261,7 +261,7 @@ class SyslogProcessorTest extends TestCase
         $record = $this->getRecord();
         $record['component'] = 'fooBar';
         $record['app'] = 'baz';
-        $processor = $this->getSysLogProcessor();
+        $processor = $this->getStdoutProcessor();
         $newRecord = $processor($record);
         $this->assertArrayHasKey('component', $newRecord);
         $this->assertArrayHasKey('app', $newRecord);
@@ -274,7 +274,7 @@ class SyslogProcessorTest extends TestCase
         $record = $this->getRecord(Logger::WARNING, str_repeat('batman', 1000));
         $record['component'] = 'fooBar';
         $record['app'] = 'baz';
-        $processor = $this->getSysLogProcessor();
+        $processor = $this->getStdoutProcessor();
         $newRecord = $processor($record);
         $this->assertArrayHasKey('component', $newRecord);
         $this->assertArrayHasKey('app', $newRecord);


### PR DESCRIPTION
Fixes: #134 

Changes:

- replaced syrup_syslog by syrup_stdout handler (in both dev and prod) to log to `php://stdout`
- renamed syslog processor service and all related files
- updated exception handler to log to `php://stdout`