### PR TITLE
Separate function to generate kill queue name

### DIFF
--- a/src/Keboola/Syrup/Service/Queue/QueueFactory.php
+++ b/src/Keboola/Syrup/Service/Queue/QueueFactory.php
@@ -10,6 +10,7 @@ namespace Keboola\Syrup\Service\Queue;
 use Aws\Sqs\SqsClient;
 use Doctrine\DBAL\Connection;
 use Keboola\Syrup\Exception\ApplicationException;
+use Keboola\Syrup\Utility\Utility;
 
 class QueueFactory
 {
@@ -29,8 +30,7 @@ class QueueFactory
     public function get($name = 'default')
     {
         if ($name == 'kill') {
-            $hostnameArr = explode('.', gethostname());
-            $name = 'syrup_kill_' . array_shift($hostnameArr);
+            $name = Utility::generateKillQueueName(gethostname());
         }
 
         $sql = "SELECT access_key, secret_key, region, url FROM {$this->dbTable} WHERE id = '{$name}'";

--- a/src/Keboola/Syrup/Utility/Utility.php
+++ b/src/Keboola/Syrup/Utility/Utility.php
@@ -234,4 +234,14 @@ class Utility
         $s = trim($s, '_');
         return $s;
     }
+
+    /**
+     * Generates kill queue name form provided hostname
+     * @param $hostname
+     * @return string
+     */
+    public static function generateKillQueueName($hostname)
+    {
+        return 'syrup_kill_' . self::webalize(str_replace('.keboola.com', '', $hostname));
+    }
 }

--- a/tests/Keboola/Syrup/Utility/GenerateKillQueueNameTest.php
+++ b/tests/Keboola/Syrup/Utility/GenerateKillQueueNameTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Keboola\Syrup\Tests\Service;
+
+use Keboola\Syrup\Utility\Utility;
+
+class GenerateKillQueueNameTest extends \PHPUnit_Framework_TestCase
+{
+    public function testReplaceDomainName()
+    {
+        $this->assertEquals(
+            'syrup_kill_i_0964292c20ee25e51',
+            Utility::generateKillQueueName('i-0964292c20ee25e51.keboola.com')
+        );
+    }
+
+    public function testReplaceDotByUnderscore()
+    {
+        $this->assertEquals(
+            'syrup_kill_ip_10_0_41_63_ec2_internal',
+            Utility::generateKillQueueName('ip-10-0-41-63.ec2.internal')
+        );
+    }
+}


### PR DESCRIPTION
Changes:

- util function to generate kill queue name (copied from syrup-queue and webalized), added tests
- ^ use new function in QueueFactory when getting `kill` queue