### PR TITLE
Add option to override storage api client backoffMaxTries via env var

### DIFF
--- a/src/Keboola/Syrup/Service/StorageApi/StorageApiService.php
+++ b/src/Keboola/Syrup/Service/StorageApi/StorageApiService.php
@@ -55,6 +55,10 @@ class StorageApiService
 
     public function getBackoffTries($hostname)
     {
+        if (getenv('STORAGE_API_CLIENT_BACKOFF_MAX_TRIES')) {
+            return getenv('STORAGE_API_CLIENT_BACKOFF_MAX_TRIES');
+        }
+
         // keep the backoff settings minimal for API servers
         if (false === strstr($hostname, 'worker')) {
             return 3;

--- a/tests/Keboola/Syrup/Service/StorageApi/StorageApiServiceTest.php
+++ b/tests/Keboola/Syrup/Service/StorageApi/StorageApiServiceTest.php
@@ -80,6 +80,11 @@ class StorageApiServiceTest extends WebTestCase
         /** @var StorageApiService $storageApiService */
         $storageApiService = $container->get('syrup.storage_api');
 
+        putenv('STORAGE_API_CLIENT_BACKOFF_MAX_TRIES=7');
+        $backoffTries = $storageApiService->getBackoffTries(gethostname());
+        $this->assertEquals(7, $backoffTries);
+        putenv('STORAGE_API_CLIENT_BACKOFF_MAX_TRIES');
+
         $backoffTries = $storageApiService->getBackoffTries('syrup-worker.keboola.com');
         $this->assertEquals(11, $backoffTries);
 


### PR DESCRIPTION
Fixes #139 

Changes:

- add option to override backoffMaxTries for storage api via env var

Rozhodol som sa spravit to menej invazivne a len pridal moznost prepisat to. Slo by to ako dalsi minor release syrupu  v11