### PR TITLE
Don't send notice event to SAPI

### DIFF
--- a/src/Keboola/Syrup/Monolog/Handler/StorageApiHandler.php
+++ b/src/Keboola/Syrup/Monolog/Handler/StorageApiHandler.php
@@ -53,7 +53,7 @@ class StorageApiHandler extends \Monolog\Handler\AbstractHandler
     {
         $this->initStorageApiClient();
 
-        if (!$this->storageApiClient || $record['level'] == Logger::DEBUG) {
+        if (!$this->storageApiClient || $record['level'] == Logger::DEBUG || $record['level'] == Logger::NOTICE) {
             return false;
         }
 

--- a/tests/Keboola/Syrup/Monolog/Handler/StorageApiHandlerTest.php
+++ b/tests/Keboola/Syrup/Monolog/Handler/StorageApiHandlerTest.php
@@ -107,11 +107,7 @@ class StorageApiHandlerTest extends TestCase
         // wait for elastic search to update
         sleep(2);
         $events = $client->listEvents(['q' => 'message: noticeMessage + runId:' . $client->getRunId()]);
-        $this->assertEquals(1, count($events));
-        $event = $events[0];
-        $this->assertEquals(Event::TYPE_WARN, $event['type']);
-        $this->assertEquals('noticeMessage', $event['message']);
-        $this->assertEquals('', $event['description']);
+        $this->assertCount(0, $events);
     }
 
     public function testHandlerMessageWarning()


### PR DESCRIPTION
Related to: https://github.com/keboola/orchestrator-bundle/pull/96

Přestaneme NOTICE logovat do SAPI. @odinuv [říká že to nic nerozbije](https://github.com/keboola/orchestrator-bundle/pull/96#issuecomment-523909026).
Updatneme první na zdockerovaném orchestratoru.

Je to nasazené v syrup v11 PR orchestrátoru https://github.com/keboola/orchestrator-bundle/pull/96 a tam pak nahozená ve zdockerovaném orchestrátoru https://github.com/keboola/orchestrator-router/pull/1 který je na testingu místo původního.

Tady je vidět log s NOTICE https://papertrailapp.com/beta/systems/syrup-testing-orchestrator-router/events?focus=1103715139443626036&selected=1103715139443626036

![image](https://user-images.githubusercontent.com/903531/63944466-d7136b00-ca71-11e9-85a1-a32bbce421fd.png)


Která v eventech testovacího projektu není
https://connection.keboola.com/admin/projects/6635/storage-explorer
