### PR TITLE
SQS timeouts

### DIFF
--- a/src/Keboola/Syrup/Service/Queue/QueueFactory.php
+++ b/src/Keboola/Syrup/Service/Queue/QueueFactory.php
@@ -49,7 +49,11 @@ class QueueFactory
         $data = [
             'region' => $region,
             'version' => '2012-11-05',
-            'retries' => 40
+            'retries' => 40,
+            'http' => [
+                'connect_timeout' => 10,
+                'timeout' => 120,
+            ],
         ];
 
         if ($key != null && $secret != null) {


### PR DESCRIPTION
Related to: https://github.com/keboola/devops/issues/124

Myslím si  že nenastavený tím pádem neomezený `connect_timeout` by mohl být za vytuháváním výběru front. 
Na sapi kde ho nastavený máme se to neděje (nebo o tom nevíme) https://github.com/keboola/connection/blob/2c16c5280d6af24fc2f5a123a7ede82f7ee32e64/legacy-app/application/configs/parameters.yml#L10

Relasnul bych a přes https://github.com/keboola/syrup-queue/pull/100 zkusil nahodit do provisioningu.
